### PR TITLE
remove falsify() 'arg_types' param

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3,66 +3,49 @@ const zigthesis = @import("zigthesis.zig");
 const utils = @import("utils.zig");
 
 pub fn main() void {
-    zigthesis.falsify(
-        struct {
-            pub fn pred(args: std.meta.Tuple(&.{ i32, i32, i32 })) bool {
-                const x = args[0];
-                const y = args[1];
-                const z = args[2];
+    zigthesis.falsify(struct {
+        pub fn pred(args: struct { i32, i32, i32 }) bool {
+            const x = args[0];
+            const y = args[1];
+            const z = args[2];
 
-                return (x + y) * z == x * (y + z);
-            }
-        }.pred,
-        &[_]type{ i32, i32, i32 },
-        "Example 1"
-    );
+            return (x + y) * z == x * (y + z);
+        }
+    }.pred, "Example 1");
 
-    zigthesis.falsify(
-        struct {
-            pub fn pred(args: std.meta.Tuple(&.{ i32, i32 })) bool {
-                const x = args[0];
-		const y = args[1];
+    zigthesis.falsify(struct {
+        pub fn pred(args: struct { i32, i32 }) bool {
+            const x = args[0];
+            const y = args[1];
 
-                return x*y == y*x;
-            }
-        }.pred,
-        &[_]type{ i32, i32 },
-        "Commutative Property of Multiplication (Integers)"
-    );
-    zigthesis.falsify(
-        struct {
-            pub fn pred(args: std.meta.Tuple(&.{ i32, i32 })) bool {
-                const x = args[0];
-                const y = args[1];
+            return x * y == y * x;
+        }
+    }.pred, "Commutative Property of Multiplication (Integers)");
 
-                return x-y == y-x;
-            }
-        }.pred,
-        &[_]type{ i32, i32 },
-        "Commutative Property of Subtraction (Integers)" 
-    );
-    zigthesis.falsify(
-        struct {
-            pub fn pred(args: std.meta.Tuple(&.{ f32, f32, f32 })) bool {
-                const x = args[0];
-                const y = args[1];
-                const z = args[2];
+    zigthesis.falsify(struct {
+        pub fn pred(args: struct { i32, i32 }) bool {
+            const x = args[0];
+            const y = args[1];
 
-                return (x + y) + z == x + (y + z);
-            }
-        }.pred,
-        &[_]type{ f32, f32, f32},
-        "Associativity of Floats"
-    );
-    zigthesis.falsify(
-        struct {
-            pub fn pred(args: std.meta.Tuple(&.{[3]i32})) bool {
-                const x = args[0];
+            return x - y == y - x;
+        }
+    }.pred, "Commutative Property of Subtraction (Integers)");
 
-               return utils.sum(x[0..]) < 100;
-            }
-        }.pred,
-        &[_]type{[3]i32},
-        "Sum of Elements in List"
-    );
+    zigthesis.falsify(struct {
+        pub fn pred(args: struct { f32, f32, f32 }) bool {
+            const x = args[0];
+            const y = args[1];
+            const z = args[2];
+
+            return (x + y) + z == x + (y + z);
+        }
+    }.pred, "Associativity of Floats");
+
+    zigthesis.falsify(struct {
+        pub fn pred(args: struct { [3]i32 }) bool {
+            const x = args[0];
+
+            return utils.sum(x[0..]) < 100;
+        }
+    }.pred, "Sum of Elements in List");
 }

--- a/src/zigthesis.zig
+++ b/src/zigthesis.zig
@@ -1,28 +1,23 @@
 const std = @import("std");
 const generate = @import("generate.zig");
 
+const MAX_DURATION_MS: u64 = 15 * 1000;
 
-const MAX_DURATION_MS: u64 = 15 * 1000; 
-
-pub fn falsify(
-    comptime Predicate: anytype,
-    comptime arg_types: []const type,
-    test_name: []const u8
-) void {
-    const gen = generate.createGenerator(arg_types);
+pub fn falsify(predicate: anytype, test_name: []const u8) void {
+    const gen = generate.Generator(@TypeOf(predicate));
     const start_time = std.time.milliTimestamp();
     while (true) {
         const current_time = std.time.milliTimestamp();
         if (current_time - start_time >= MAX_DURATION_MS) {
             std.debug.print("No falsifying case found for {s}.\n", .{test_name});
-	    return;
+            return;
         }
 
         const args = gen.generate();
-        const result = @call(.auto, Predicate, .{args});
+        const result = predicate(args);
         if (!result) {
             std.debug.print("Falsifying case for {s}: {any}\n", .{ test_name, args });
-	    return;
+            return;
         }
     }
 }


### PR DESCRIPTION
this way you don't have to specify the arg types twice when calling falsify().  now pred()'s first param type is used instead.

* use struct tuples instead of meta.ArgsTuple()
* simplify things by inlining some functions

sorry for the extra formatting changes