### PR TITLE
trying out non-crypto library

### DIFF
--- a/src/generate.zig
+++ b/src/generate.zig
@@ -4,36 +4,37 @@ const std = @import("std");
 const A = 65;
 const z = 122;
 
+
 pub fn Generator(comptime Predicate: type) type {
     const Arg = @typeInfo(Predicate).Fn.params[0].type.?;
 
     return struct {
-        pub fn generate() Arg {
+        pub fn generate(random: std.rand.Random) Arg {
             var arg: Arg = undefined;
             inline for (@typeInfo(Arg).Struct.fields) |field| {
-                @field(arg, field.name) = generateField(field.type);
+                @field(arg, field.name) = generateField(random, field.type);
             }
             return arg;
         }
     };
 }
 
-fn generateField(comptime T: type) T {
+fn generateField(random: std.rand.Random, comptime T: type) T {  
     switch (@typeInfo(T)) {
         .Int => {
             if (T == u8){
-                return std.crypto.random.intRangeAtMost(T, A, z);
+                return random.intRangeAtMost(T, A, z);
             } else {
-                return std.crypto.random.intRangeAtMost(T, std.math.pow(i32, -10, 3), std.math.pow(i32, 10, 3));
+                return random.intRangeAtMost(T, std.math.pow(i32, -10, 3), std.math.pow(i32, 10, 3));
             }
         },
         .Float => {
-            return std.crypto.random.float(T);
+            return random.float(T);
         },
         .Array => |array_info| {
             var array: T = undefined;
             for (&array) |*item| {
-                    item.* = generateField(array_info.child);
+                    item.* = generateField(random, array_info.child);
             }
             return array;
         },

--- a/src/zigthesis.zig
+++ b/src/zigthesis.zig
@@ -1,29 +1,23 @@
 const std = @import("std");
 const generate = @import("generate.zig");
-
 const MAX_DURATION_MS: u64 = 10 * 1000;
-
-
-pub fn getRandom() !std.rand.Random {
-    var prng = std.rand.DefaultPrng.init(blk: {
-        var seed: u64 = undefined;
-        try std.posix.getrandom(std.mem.asBytes(&seed));
-        break :blk seed;
-    });
-    return prng.random();
-}
 
 pub fn falsify(predicate: anytype, test_name: []const u8) !void {
     const gen = generate.Generator(@TypeOf(predicate));
     const start_time = std.time.milliTimestamp();
-    const random = try getRandom();
+    var prng = blk: {
+        var seed: u64 = undefined;
+        try std.posix.getrandom(std.mem.asBytes(&seed));
+        break :blk std.rand.DefaultPrng.init(seed);
+    };
+    const random = prng.random();
+
     while (true) {
         const current_time = std.time.milliTimestamp();
         if (current_time - start_time >= MAX_DURATION_MS) {
             std.debug.print("{s} succeeded.\n", .{test_name});
             return;
         }
-
         const args = gen.generate(random);
         const result = predicate(args);
         if (!result) {

--- a/src/zigthesis.zig
+++ b/src/zigthesis.zig
@@ -3,9 +3,20 @@ const generate = @import("generate.zig");
 
 const MAX_DURATION_MS: u64 = 10 * 1000;
 
-pub fn falsify(predicate: anytype, test_name: []const u8) void {
+
+pub fn getRandom() !std.rand.Random {
+    var prng = std.rand.DefaultPrng.init(blk: {
+        var seed: u64 = undefined;
+        try std.posix.getrandom(std.mem.asBytes(&seed));
+        break :blk seed;
+    });
+    return prng.random();
+}
+
+pub fn falsify(predicate: anytype, test_name: []const u8) !void {
     const gen = generate.Generator(@TypeOf(predicate));
     const start_time = std.time.milliTimestamp();
+    const random = try getRandom();
     while (true) {
         const current_time = std.time.milliTimestamp();
         if (current_time - start_time >= MAX_DURATION_MS) {
@@ -13,7 +24,7 @@ pub fn falsify(predicate: anytype, test_name: []const u8) void {
             return;
         }
 
-        const args = gen.generate();
+        const args = gen.generate(random);
         const result = predicate(args);
         if (!result) {
             std.debug.print("{s} failed with case: {any}\n", .{ test_name, args });

--- a/tests/test_falsify.zig
+++ b/tests/test_falsify.zig
@@ -3,7 +3,7 @@ const zigthesis = @import("zigthesis");
 const utils = @import("utils");
 
 test "falsify" {
-    zigthesis.falsify(struct {
+    try zigthesis.falsify(struct {
         pub fn pred(args: struct { i32, i32, i32 }) bool {
             const x = args[0];
             const y = args[1];
@@ -13,7 +13,7 @@ test "falsify" {
         }
     }.pred, "Weid Distributive");
 
-    zigthesis.falsify(struct {
+    try zigthesis.falsify(struct {
         pub fn pred(args: struct { i32, i32 }) bool {
             const x = args[0];
             const y = args[1];
@@ -22,7 +22,7 @@ test "falsify" {
         }
     }.pred, "Commutative Property of Multiplication (Integers)");
 
-    zigthesis.falsify(struct {
+    try zigthesis.falsify(struct {
         pub fn pred(args: struct { i32, i32 }) bool {
             const x = args[0];
             const y = args[1];
@@ -31,7 +31,7 @@ test "falsify" {
         }
     }.pred, "Commutative Property of Subtraction (Integers)");
 
-    zigthesis.falsify(struct {
+    try zigthesis.falsify(struct {
         pub fn pred(args: struct { f32, f32, f32 }) bool {
             const x = args[0];
             const y = args[1];
@@ -41,7 +41,7 @@ test "falsify" {
         }
     }.pred, "Associativity of Floats");
 
-    zigthesis.falsify(struct {
+    try zigthesis.falsify(struct {
         pub fn pred(args: struct { [3]i32 }) bool {
             const l1 = args[0];
 
@@ -49,7 +49,7 @@ test "falsify" {
         }
     }.pred, "Sum Less Than 100");
 
-    zigthesis.falsify(struct {
+    try zigthesis.falsify(struct {
         pub fn pred(args: struct { [6]u8 }) bool {
             const x = args[0];
 
@@ -57,7 +57,7 @@ test "falsify" {
         }
     }.pred, "'xyz' Not a Substring"); //can view the falsifying case in string format by printing out with {s}
 
-    zigthesis.falsify(struct {
+    try zigthesis.falsify(struct {
         pub fn pred(args: struct { [3]i32, [3]i32 }) bool {
             const l1 = args[0];
 	    const l2 = args[1];


### PR DESCRIPTION
Meant to fix #4 , but doesn't work.  `zig build test` generates a memory address issue:

```bash
test
└─ run test failure
General protection exception (no address available)
/usr/local/zig/lib/std/Random.zig:254:9: 0x1050ffe in intRangeAtMost__anon_5624 (test)
        return @bitCast(result);
        ^
???:?:?: 0xfff81dbf16845fdd in ??? (???)
Unwind information for `???:0xfff81dbf16845fdd` was not available, trace may be incomplete

error: while executing test 'test_falsify.test.falsify', the following command terminated with signal 6 (expected exited with code 0):
/home/<redacted>/zigthesis/zig-cache/o/76a0932cae5a14decc243bf0def7251a/test --listen=- 
Build Summary: 1/3 steps succeeded; 1 failed; 1/1 tests passed (disable with --summary none)

test transitive failure
└─ run test failure
error: the following build command failed with exit code 1:
/home/<redacted>/zigthesis/zig-cache/o/ed0d5c383c9841f0876aa72c4f137cb6/build /usr/local/zig/zig /home/<redacted>/zigthesis /home/<redacted>/zigthesis/zig-cache /home/<redacted>/.cache/zig --seed 0xc6ad37c -Z03e7d183ff6eb317 test

```
<!--
ELLIPSIS_HIDDEN
-->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f66c24aa0f743c56a04ac3525ffae923b3a7770a  | 
|--------|--------|

### Summary:
This PR attempts to replace cryptographic random generation with a non-crypto library in `generateField`, modifies `falsify` to use this new generator, and updates tests, but encounters a memory address issue.

**Key points**:
- Replaces `std.crypto.random` with `std.rand.Random` in `generateField` function.
- Modifies `falsify` in `zigthesis.zig` to initialize and pass the random generator.
- Updates tests in `test_falsify.zig` to handle errors using `try`.
- Encounters a memory address issue during testing, indicating a problem with the changes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->