### PR TITLE
No args struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,7 @@ An example test and output,
 
 ```zig
     zigthesis.falsify(struct {
-        pub fn pred(args: struct { i32, i32, i32 }) bool {
-            const x = args[0];
-            const y = args[1];
-            const z = args[2];
-
+        pub fn pred(x: i32, y: i32, z: i32) bool {
             return (x + y) * z == x * (y + z);
         }
     }.pred, "Weird Distributive");

--- a/README.md
+++ b/README.md
@@ -20,12 +20,10 @@ zig build test
 An example test and output, 
 
 ```zig
-    zigthesis.falsify(struct {
-        pub fn pred(x: i32, y: i32, z: i32) bool {
-            return (x + y) * z == x * (y + z);
-        }
-    }.pred, "Weird Distributive");
-
+fn weirdDistributive(x: i32, y: i32, z: i32) bool {
+    return (x + y) * z == x * (y + z);
+}
+try zigthesis.falsify( weirdDistributive, "Weird Distributive");
 ```
 
 Output:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Output:
 Weird Distributive failed with case: { 480, -670, 646 }
 ```
 
-Zigthesis will return a success, if no falsifying test case was found within MAX_DURATION_MS (currently set at 10 seconds).
+Zigthesis will return a success, if no falsifying test case was found within MAX_DURATION_MS (currently set at 5 seconds).
 
 
 REMARK: This is tiny and doesn't do much for now. Next steps would be to make a simple foundation for generating and testing properties with:

--- a/src/generate.zig
+++ b/src/generate.zig
@@ -5,21 +5,7 @@ const A = 65;
 const z = 122;
 
 
-pub fn Generator(comptime Predicate: type) type {
-    const Arg = @typeInfo(Predicate).Fn.params[0].type.?;
-
-    return struct {
-        pub fn generate(random: std.rand.Random) Arg {
-            var arg: Arg = undefined;
-            inline for (@typeInfo(Arg).Struct.fields) |field| {
-                @field(arg, field.name) = generateField(random, field.type);
-            }
-            return arg;
-        }
-    };
-}
-
-fn generateField(random: std.rand.Random, comptime T: type) T {  
+pub fn generateField(random: std.rand.Random, comptime T: type) T {  
     switch (@typeInfo(T)) {
         .Int => {
             if (T == u8){

--- a/tests/test_falsify.zig
+++ b/tests/test_falsify.zig
@@ -2,49 +2,41 @@ const std = @import("std");
 const zigthesis = @import("zigthesis");
 const utils = @import("utils");
 
+fn weirdDistributive(x: i32, y: i32, z: i32) bool {
+    return (x + y) * z == x * (y + z);
+}
+
+fn commutativeMultiplication(x: i32, y: i32) bool {
+    return x * y == y * x;
+}
+
+fn commutativeSubtraction(x: i32, y: i32) bool {
+    return x - y == y - x;
+}
+
+fn associativityFloats(x: f32, y: f32, z: f32) bool {
+    return (x + y) + z == x + (y + z);
+}
+
+fn sumLessThan100(l1: [3]i32) bool {
+    return utils.sum(l1[0..]) < 100;
+}
+
+fn xyzNotSubstring(a: [6]u8) bool {
+    return std.mem.indexOf(u8, &a, "xyz") == null;
+}
+
+fn lengthOfPairwiseListSum(l1: [3]i32, l2: [3]i32) bool {
+    const combined = utils.sumPairwise(l1[0..], l2[0..]);
+    return combined.len == l1.len;
+}
+
 test "falsify" {
-    try zigthesis.falsify(struct {
-        pub fn pred(x: i32, y: i32, z: i32) bool {
-            return (x + y) * z == x * (y + z);
-        }
-    }.pred , "Weid Distributive");
-
-    try zigthesis.falsify(struct {
-        pub fn pred(x: i32, y: i32) bool {
-            return x * y == y * x;
-        }
-    }.pred, "Commutative Property of Multiplication (Integers)");
-
-    try zigthesis.falsify(struct {
-        pub fn pred(x: i32, y: i32) bool {
-            return x - y == y - x;
-        }
-    }.pred, "Commutative Property of Subtraction (Integers)");
-
-    try zigthesis.falsify(struct {
-        pub fn pred(x: f32, y: f32, z: f32) bool {
-            return (x + y) + z == x + (y + z);
-        }
-    }.pred, "Associativity of Floats");
-
-    try zigthesis.falsify(struct {
-        pub fn pred(l1: [3]i32 ) bool {
-            return utils.sum(l1[0..]) < 100;
-        }
-    }.pred, "Sum Less Than 100");
-
-    try zigthesis.falsify(struct {
-        pub fn pred(a: [6]u8) bool {
-            return std.mem.indexOf(u8, &a, "xyz") == null;
-        }
-    }.pred, "'xyz' Not a Substring"); //can view the falsifying case in string format by printing out with {s}
-
-    try zigthesis.falsify(struct {
-        pub fn pred(l1: [3]i32, l2: [3]i32 ) bool {
-	        const combined = utils.sumPairwise(l1[0..],l2[0..]);
-
-            return combined.len == l1.len;
-        }
-    }.pred, "Length of Pairwise List Sum");
-
+    try zigthesis.falsify(weirdDistributive, "Weird Distributive");
+    try zigthesis.falsify(commutativeMultiplication, "Commutative Property of Multiplication (Integers)");
+    try zigthesis.falsify(commutativeSubtraction, "Commutative Property of Subtraction (Integers)");
+    try zigthesis.falsify(associativityFloats, "Associativity of Floats");
+    try zigthesis.falsify(sumLessThan100, "Sum Less Than 100");
+    try zigthesis.falsify(xyzNotSubstring, "'xyz' Not a Substring");
+    try zigthesis.falsify(lengthOfPairwiseListSum, "Length of Pairwise List Sum");
 }

--- a/tests/test_falsify.zig
+++ b/tests/test_falsify.zig
@@ -4,65 +4,44 @@ const utils = @import("utils");
 
 test "falsify" {
     try zigthesis.falsify(struct {
-        pub fn pred(args: struct { i32, i32, i32 }) bool {
-            const x = args[0];
-            const y = args[1];
-            const z = args[2];
-
+        pub fn pred(x: i32, y: i32, z: i32) bool {
             return (x + y) * z == x * (y + z);
         }
-    }.pred, "Weid Distributive");
+    }.pred , "Weid Distributive");
 
     try zigthesis.falsify(struct {
-        pub fn pred(args: struct { i32, i32 }) bool {
-            const x = args[0];
-            const y = args[1];
-
+        pub fn pred(x: i32, y: i32) bool {
             return x * y == y * x;
         }
     }.pred, "Commutative Property of Multiplication (Integers)");
 
     try zigthesis.falsify(struct {
-        pub fn pred(args: struct { i32, i32 }) bool {
-            const x = args[0];
-            const y = args[1];
-
+        pub fn pred(x: i32, y: i32) bool {
             return x - y == y - x;
         }
     }.pred, "Commutative Property of Subtraction (Integers)");
 
     try zigthesis.falsify(struct {
-        pub fn pred(args: struct { f32, f32, f32 }) bool {
-            const x = args[0];
-            const y = args[1];
-            const z = args[2];
-
+        pub fn pred(x: f32, y: f32, z: f32) bool {
             return (x + y) + z == x + (y + z);
         }
     }.pred, "Associativity of Floats");
 
     try zigthesis.falsify(struct {
-        pub fn pred(args: struct { [3]i32 }) bool {
-            const l1 = args[0];
-
+        pub fn pred(l1: [3]i32 ) bool {
             return utils.sum(l1[0..]) < 100;
         }
     }.pred, "Sum Less Than 100");
 
     try zigthesis.falsify(struct {
-        pub fn pred(args: struct { [6]u8 }) bool {
-            const x = args[0];
-
-            return std.mem.indexOf(u8, &x, "xyz") == null;
+        pub fn pred(a: [6]u8) bool {
+            return std.mem.indexOf(u8, &a, "xyz") == null;
         }
     }.pred, "'xyz' Not a Substring"); //can view the falsifying case in string format by printing out with {s}
 
     try zigthesis.falsify(struct {
-        pub fn pred(args: struct { [3]i32, [3]i32 }) bool {
-            const l1 = args[0];
-	    const l2 = args[1];
-
-	    const combined = utils.sumPairwise(l1[0..],l2[0..]);
+        pub fn pred(l1: [3]i32, l2: [3]i32 ) bool {
+	        const combined = utils.sumPairwise(l1[0..],l2[0..]);
 
             return combined.len == l1.len;
         }


### PR DESCRIPTION
steamlined calling `zigthesis.falsify`
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e15eeba5f27fe9113cda44caeca0d31b3e381be0  | 
|--------|--------|

### Summary:
This PR streamlines the `falsify` function in the `zigthesis` library by allowing direct passing of predicate functions, simplifies argument generation, updates test cases, and reduces test duration.

**Key points**:
- Simplified the `falsify` function call by directly passing predicate functions instead of encapsulating them in structs.
- Updated argument generation in `generateField` to support direct predicate function calls.
- Refactored test cases in `tests/test_falsify.zig` to use the new calling convention.
- Reduced the maximum test duration from 10 seconds to 5 seconds in `zigthesis.zig`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->