### PR TITLE
adding boundaries and shrinkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,21 @@ try zigthesis.falsify(weirdDistributive, "weird distributive");
 
 Output:
 ```
-weird distributive             failed for { -287, 121, -670 }
+weird distributive             failed for { 1, 1, 0 }
 ```
 
 Zigthesis will return a success, if no falsifying test case was found within MAX_DURATION_MS (currently set at 5 seconds).
 
 
-REMARK: This is tiny and doesn't do much for now. Next steps would be to make a simple foundation for generating and testing properties with:
+INITIAL REMARK: This is tiny and doesn't do much for now. Next steps would be to make a simple foundation for generating and testing properties with:
 1. ~~Floats~~
 2. ~~Arrays (of floats/integers)~~
 3. ~~Vectors~~
 4. ~~Strings~~
 5. ~~User Defined Struct~~
 
-~~Along with a bit of code of clean up (i.e. making a testing directory etc.).~~
+## STATUS:
 
-In Hypothesis, they had both generating and minimizing components [(detailed here)](https://github.com/HypothesisWorks/hypothesis/blob/94037edcf6f5256214a8b39e266cc9452e34704c/README.rest)
-that I do not implement. This will be required for richer test cases.
+- Currently `main.zig` only has an empty main function. This is confusing. Is there a way refactor to make this more intuitive?
+- Implemented a [bad shrinking](https://propertesting.com/book_shrinking.html) mechanism. More thought needs to be put into this.
 

--- a/src/shrink.zig
+++ b/src/shrink.zig
@@ -59,15 +59,15 @@ fn shrinkArray(comptime T: type, value: T, predicate: anytype, args: anytype) T 
     var i: usize = 0;
     while (i < info.len) : (i += 1) {
         var shrunk = value;
-        const curr = i;
         shrunk[i] = shrink(info.child, value[i], struct {
-            fn inner(v: info.child, a: @TypeOf(args)) bool {
+            fn inner(v: info.child, a: @TypeOf(.{args} ++ .{i, value})) bool {
                 var temp = a[a.len-1];
+                const curr = a[a.len-2];
                 temp[curr] = v;
-                return predicate(temp, a[0..a.len-1] ++ .{temp});
+                return predicate(temp, a[0]);
             }
-        }.inner, args ++ .{value});
-        if (!predicate(shrunk, args ++ .{value})) {
+        }.inner, .{args} ++ .{i, value});
+        if (!predicate(shrunk, args)) {
             return shrunk;
         }
     }

--- a/src/shrink.zig
+++ b/src/shrink.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+
+pub fn shrink(comptime T: type, value: T, predicate: anytype, args: anytype) T {
+    return switch (@typeInfo(T)) {
+        .Int => shrinkInt(T, value, predicate, args),
+        .Float => shrinkFloat(T, value, predicate, args),
+        .Array => value, //shrinkArray(T, value, predicate, args),
+        .Struct => value, //shrinkStruct(T, value, predicate, args),
+        else => value,
+    };
+}
+
+fn shrinkInt(comptime T: type, value: T, predicate: anytype, args: anytype) T {
+    if (T == u8){ return value; }
+    var current = value;
+    const targets = [_]T{0, 1, -1, @divTrunc(value, 2), @divTrunc(-value, 2)};
+
+    for (targets) |target| {
+        if (target != current and !predicate(target, args)) {
+            return target;
+        }
+    }
+
+    while (current != 0) {
+        const next = @divTrunc(current, 2);
+        if (next != current and !predicate(next, args)) {
+            return next;
+        }
+        current = next;
+    }
+
+    return value;
+}
+
+fn shrinkFloat(comptime T: type, value: T, predicate: anytype, args: anytype) T {
+    var current = value;
+    const targets = [_]T{0, 1, -1, @divTrunc(value, 2), @divTrunc(-value, 2)};
+
+    for (targets) |target| {
+        if (target != current and !predicate(target, args)) {
+            return target;
+        }
+    }
+
+    while (current != 0) {
+        const next = @divTrunc(current, 2);
+        if (next != current and !predicate(next, args)) {
+            return next;
+        }
+        current = next;
+    }
+
+    return value;
+}
+
+fn shrinkArray(comptime T: type, value: T, predicate: anytype, args: anytype) T {
+    const info = @typeInfo(T).Array;
+    // Try shrinking individual elements
+    var i: usize = 0;
+    while (i < info.len) : (i += 1) {
+        var shrunk = value;
+        const curr = i;
+        shrunk[i] = shrink(info.child, value[i], struct {
+            fn inner(v: info.child, a: @TypeOf(args)) bool {
+                var temp = value;
+                temp[curr] = v;
+                return predicate(temp, a);
+            }
+        }.inner, args);
+        if (!predicate(shrunk, args)) {
+            return shrunk;
+        }
+    }
+    return value;
+}
+
+//fn shrinkStruct(comptime T: type, value: T, predicate: anytype, args: anytype) T {
+//    var current = value;
+//    const info = @typeInfo(T).Struct;
+//    inline for (info.fields) |field| {
+//        var shrunk = current;
+//        @field(shrunk, field.name) = shrink(field.type, @field(current, field.name), struct {
+//            fn inner(v: field.type, a: @TypeOf(args)) bool {
+//                var temp = current;
+//                @field(temp, field.name) = v;
+//                return predicate(temp, a);
+//            }
+//        }.inner, args);
+//       if (!predicate(shrunk, args)) {
+//            return shrunk;
+//        }
+//    }
+//    return current;
+//}

--- a/src/shrink.zig
+++ b/src/shrink.zig
@@ -4,7 +4,7 @@ pub fn shrink(comptime T: type, value: T, predicate: anytype, args: anytype) T {
     return switch (@typeInfo(T)) {
         .Int => shrinkInt(T, value, predicate, args),
         .Float => shrinkFloat(T, value, predicate, args),
-        .Array => value, //shrinkArray(T, value, predicate, args),
+        .Array => shrinkArray(T, value, predicate, args),
         .Struct => value, //shrinkStruct(T, value, predicate, args),
         else => value,
     };
@@ -62,12 +62,12 @@ fn shrinkArray(comptime T: type, value: T, predicate: anytype, args: anytype) T 
         const curr = i;
         shrunk[i] = shrink(info.child, value[i], struct {
             fn inner(v: info.child, a: @TypeOf(args)) bool {
-                var temp = value;
+                var temp = a[a.len-1];
                 temp[curr] = v;
-                return predicate(temp, a);
+                return predicate(temp, a[0..a.len-1] ++ .{temp});
             }
-        }.inner, args);
-        if (!predicate(shrunk, args)) {
+        }.inner, args ++ .{value});
+        if (!predicate(shrunk, args ++ .{value})) {
             return shrunk;
         }
     }

--- a/src/zigthesis.zig
+++ b/src/zigthesis.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const generate = @import("generate.zig");
+const shrink = @import("shrink.zig");
 const MAX_DURATION_MS: u64 = 5 * 1000;
 
 pub fn falsify(predicate: anytype, test_name: []const u8) !void {
@@ -23,8 +24,24 @@ pub fn falsify(predicate: anytype, test_name: []const u8) !void {
         }
         const result = @call(.auto, predicate, args);
         if (!result) {
+            args = shrinkArgs(predicate, args);
             std.debug.print("{s:<30} failed for {any}\n", .{ test_name, args });
             return;
         }
     }
+}
+
+fn shrinkArgs(predicate: anytype, args: std.meta.ArgsTuple(@TypeOf(predicate))) std.meta.ArgsTuple(@TypeOf(predicate)) {
+    //const predTypeInfo = @typeInfo(@TypeOf(predicate)).Fn;
+    var shrunk_args = args; 
+    inline for (&shrunk_args, 0..) |*arg, i| {
+        arg.* = shrink.shrink(@TypeOf(arg.*), arg.*, struct {
+            fn inner(new_value: @TypeOf(arg.*), current_args: std.meta.ArgsTuple(@TypeOf(predicate))) bool {
+                var test_args = current_args;
+                @field(test_args, std.meta.fieldNames(std.meta.ArgsTuple(@TypeOf(predicate)))[i]) = new_value;
+                return @call(.auto, predicate, test_args);
+            }
+        }.inner, shrunk_args);
+    } 
+    return shrunk_args;
 }

--- a/src/zigthesis.zig
+++ b/src/zigthesis.zig
@@ -32,7 +32,6 @@ pub fn falsify(predicate: anytype, test_name: []const u8) !void {
 }
 
 fn shrinkArgs(predicate: anytype, args: std.meta.ArgsTuple(@TypeOf(predicate))) std.meta.ArgsTuple(@TypeOf(predicate)) {
-    //const predTypeInfo = @typeInfo(@TypeOf(predicate)).Fn;
     var shrunk_args = args; 
     inline for (&shrunk_args, 0..) |*arg, i| {
         arg.* = shrink.shrink(@TypeOf(arg.*), arg.*, struct {

--- a/tests/test_falsify.zig
+++ b/tests/test_falsify.zig
@@ -12,7 +12,7 @@ fn commutativeAddition(x: i32, y: i32) bool {
     return x + y == y + x;
 }
 test "Commutativity" {
-    try zigthesis.falsify(commutativeMultiplication, "multplicaitve commutativity");
+    try zigthesis.falsify(commutativeMultiplication, "multiplicative commutativity");
     try zigthesis.falsify(commutativeAddition, "additive commutativity");
 }
 

--- a/tests/test_falsify.zig
+++ b/tests/test_falsify.zig
@@ -63,9 +63,14 @@ test "Strings and Lists" {
 fn weirdDistributive(x: i32, y: i32, z: i32) bool {
     return (x + y) * z == x * (y + z);
 }
+fn weirdAbsolute(x: i32, y: i32) bool {
+    return @abs(x + y) == @abs(x) + @abs(y);
+}
 
-test "Weird Distributive" {
+test "Distributive" {
     try zigthesis.falsify(weirdDistributive, "weird distributive");
+    try zigthesis.falsify(weirdAbsolute, "weird absolute");
+    try
 }
 
 fn simpleStruct(instance: utils.structTest) bool {

--- a/tests/test_falsify.zig
+++ b/tests/test_falsify.zig
@@ -63,6 +63,7 @@ test "Strings and Lists" {
 fn weirdDistributive(x: i32, y: i32, z: i32) bool {
     return (x + y) * z == x * (y + z);
 }
+
 fn weirdAbsolute(x: i32, y: i32) bool {
     return @abs(x + y) == @abs(x) + @abs(y);
 }
@@ -70,7 +71,6 @@ fn weirdAbsolute(x: i32, y: i32) bool {
 test "Distributive" {
     try zigthesis.falsify(weirdDistributive, "weird distributive");
     try zigthesis.falsify(weirdAbsolute, "weird absolute");
-    try
 }
 
 fn simpleStruct(instance: utils.structTest) bool {


### PR DESCRIPTION
1) Added boundary values. For example, for floats, now it may try usual problem values  such as 0, infinity, or -1. 

2) I want to implement [shrinking](https://propertesting.com/book_shrinking.html). This ensures we get the simplest failing test case. Unfortunately,

```zig
fn shrinkArray(comptime T: type, value: T, predicate: anytype, args: anytype) T {
    const info = @typeInfo(T).Array;
    // Try shrinking individual elements
    var i: usize = 0;
    while (i < info.len) : (i += 1) {
        var shrunk = value;
        const curr = i;
        shrunk[i] = shrink(info.child, value[i], struct {
            fn inner(v: info.child, a: @TypeOf(args)) bool {
                var temp = value;
                temp[curr] = v;
                return predicate(temp, a);
            }
        }.inner, args);
        if (!predicate(shrunk, args)) {
            return shrunk;
        }
    }
    return value;
}
```
throws a 
```bash
 error: 'value' not accessible from inner function
                var temp = value;
```
 This is an unsurprising issue, but I can think of a fix that would not require tweaking the (already working) ``shrinkFloat`` and ``shrinkInt`` functions