### PR TITLE
Support enums, slices, pointers, optionals, and more unsigned types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-cache/
 zig-out/
+.zig-cache/

--- a/src/generate.zig
+++ b/src/generate.zig
@@ -1,30 +1,35 @@
 const std = @import("std");
 
-
 // ascii mapping
 const A = 65;
 const z = 122;
 
-
-
-pub fn generateField(random: std.rand.Random, comptime T: type) T {  
+pub fn generateField(alloc: std.mem.Allocator, random: std.rand.Random, comptime T: type) std.mem.Allocator.Error!T {
     const typeInfo = @typeInfo(T);
     switch (typeInfo) {
+        .Bool => {
+            return random.boolean();
+        },
         .Int => {
-            const len: comptime_int = if (T == u8) 4 else if (T == u32) 4 else 7;
-            var boundaries: [len]T =  undefined;
+            const len: comptime_int = if (typeInfo.Int.signedness == .signed) 7 else 4;
+            var boundaries: [len]T = undefined;
             getBoundaries(T, &boundaries);
             if (random.float(f32) < 0.2) {
                 return boundaries[random.intRangeAtMost(usize, 0, boundaries.len - 1)];
             } else {
                 if (T == u8) {
                     return random.intRangeAtMost(T, A, z);
+                } else if (T == i8) {
+                    return random.intRangeAtMost(T, std.math.minInt(T), std.math.maxInt(T));
                 } else if (T == u32) {
-                    const max = std.math.pow(T, 10, 3);
+                    const max = comptime std.math.pow(T, 10, 3);
+                    return random.intRangeAtMost(T, 0, max);
+                } else if (typeInfo.Int.signedness == .unsigned) {
+                    const max = comptime std.math.maxInt(T);
                     return random.intRangeAtMost(T, 0, max);
                 } else {
-                    const min = -std.math.pow(T, 10, 3);
-                    const max = std.math.pow(T, 10, 3);
+                    const min = comptime -std.math.pow(T, 10, 3);
+                    const max = comptime std.math.pow(T, 10, 3);
                     return random.intRangeAtMost(T, min, max);
                 }
             }
@@ -40,7 +45,7 @@ pub fn generateField(random: std.rand.Random, comptime T: type) T {
         .Array => |array_info| {
             var array: T = undefined;
             for (&array) |*item| {
-                    item.* = generateField(random, array_info.child);
+                item.* = try generateField(alloc, random, array_info.child);
             }
             return array;
         },
@@ -50,7 +55,7 @@ pub fn generateField(random: std.rand.Random, comptime T: type) T {
             var vector: T = undefined;
             var i: usize = 0;
             while (i < elementCount) : (i += 1) {
-                vector[i] = generateField(random, elementType);
+                vector[i] = try generateField(alloc, random, elementType);
             }
             const vec: @Vector(elementCount, elementType) = vector;
             return vec;
@@ -59,27 +64,80 @@ pub fn generateField(random: std.rand.Random, comptime T: type) T {
             var instance: T = undefined;
             const structInfo = typeInfo.Struct;
             inline for (structInfo.fields) |field| {
-                @field(instance, field.name) = generateField(random, field.type);
+                @field(instance, field.name) = try generateField(alloc, random, field.type);
             }
             return instance;
+        },
+        .Union => {
+            var instance: T = undefined;
+            const unionInfo = typeInfo.Union;
+            const field_index = random.intRangeAtMost(usize, 0, unionInfo.fields.len - 1);
+            switch (field_index) {
+                inline 0...unionInfo.fields.len - 1 => |i| {
+                    instance = @unionInit(T, unionInfo.fields[i].name, try generateField(alloc, random, unionInfo.fields[i].type));
+                },
+                else => unreachable,
+            }
+            return instance;
+        },
+        .Void => {
+            return {};
+        },
+        .Optional => {
+            if (random.float(f32) < 0.5) {
+                return null;
+            } else {
+                return try generateField(alloc, random, typeInfo.Optional.child);
+            }
+        },
+        .Pointer => {
+            switch (typeInfo.Pointer.size) {
+                .One => {
+                    const one = try alloc.create(typeInfo.Pointer.child);
+                    errdefer alloc.destroy(one);
+                    one.* = try generateField(alloc, random, typeInfo.Pointer.child);
+                    return one;
+                },
+                .Slice => {
+                    const len = random.intRangeAtMost(usize, 0, 10);
+                    var array = try alloc.alloc(typeInfo.Pointer.child, len);
+                    errdefer alloc.free(array);
+                    for (0..array.len) |i| {
+                        array[i] = try generateField(alloc, random, typeInfo.Pointer.child);
+                    }
+                    return array[0..array.len];
+                },
+                else => {
+                    @compileError("Pointer type '" ++ @tagName(typeInfo.Pointer.size) ++ "' not supported ");
+                },
+            }
         },
         else => @compileError("Type '" ++ @typeName(T) ++ "' not supported "),
     }
 }
 
-
 fn getBoundaries(comptime T: type, slice: []T) void {
+    const typeInfo = @typeInfo(T);
     if (T == u8) {
         var boundaries = [_]T{ A, A + 1, z - 1, z };
         @memcpy(slice, &boundaries);
+    } else if (T == i8) {
+        const min = comptime std.math.minInt(T);
+        const max =  comptime std.math.maxInt(T);
+        var boundaries = [_]T{ min, min + 1, -1, 0, 1, max - 1, max };
+        @memcpy(slice, &boundaries);
     } else if (T == u32) {
-        const max = std.math.pow(T, 10, 3);
+        const max = comptime std.math.pow(T, 10, 3);
+        var boundaries = [_]T{ 0, 1, max - 1, max };
+        @memcpy(slice, &boundaries);
+    } else if (typeInfo == .Int and typeInfo.Int.signedness == .unsigned) {
+        const max = comptime std.math.maxInt(T);
         var boundaries = [_]T{ 0, 1, max - 1, max };
         @memcpy(slice, &boundaries);
     } else {
-        const min = -std.math.pow(T, 10, 3);
-        const max = std.math.pow(T, 10, 3);
-        var boundaries = [_]T{ min, min + 1, -1 , 0, 1, max - 1, max};
+        const min = comptime -std.math.pow(T, 10, 3);
+        const max = comptime std.math.pow(T, 10, 3);
+        var boundaries = [_]T{ min, min + 1, -1, 0, 1, max - 1, max };
         @memcpy(slice, &boundaries);
     }
 }

--- a/tests/test_falsify.zig
+++ b/tests/test_falsify.zig
@@ -80,3 +80,38 @@ fn simpleStruct(instance: utils.structTest) bool {
 test "Struct Test"{
     try zigthesis.falsify(simpleStruct, "field entries in struct");
 }
+
+const AnEnum = union(enum) {
+    a : u8,
+    b : u16,
+    c : u32,
+    d : u64,
+    e : i8,
+    f : i16,
+    g : i32,
+    h : i64,
+    i : f32,
+    j : f64,
+    k : bool,
+    l : void,
+    m : [3]u8,
+    n : [3]u16,
+    o : [3]u32,
+    p : [3]u64,
+    q : [3]i8,
+    r : []const u8,
+    s : usize,
+    t : *u8,
+    u : ?u8,
+    v : u9,
+    w : []u64,
+    x : []usize,
+};
+
+fn enumTest(instance: AnEnum) bool {
+    return instance == .a;
+}
+
+test "Enum Test" {
+    try zigthesis.falsify(enumTest, "enum test");
+}


### PR DESCRIPTION
I wanted to try this with a test that generates a fairly complex enum.  Turns out that was pretty easy.  In my test case here, I also found compiler errors on u16 and u64 values.  I'm not entirely sure how values were selected here, but I made it compile.

In doing this, I also needed to pass an allocator down and allow failures to propagate up.  The one thing that's arguably wrong here is that `falsify` doesn't receive an allocator.  Since it's meant for testing, it could use the test allocator, but that's also a little weird.  I'd probably say this is a good compromise given the intended usage, but perhaps just making a separate function for those who want to supply their own allocators would be better.

Similarly, it might make sense to provide some kind of generator configuration.  Perhaps hedgehog-esque ranges or something.  We sometimes want u8 to be ASCII and sometimes just a number.  Perhaps a slice of u8 should be utf-8…

Anyway.  Not trying to bomb you with code, just running through a use case I've got.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `generateField` to support more data types and update `falsify` for allocator use, with new tests added.
> 
>   - **Behavior**:
>     - `generateField` in `generate.zig` now supports enums, slices, pointers, optionals, and unsigned types.
>     - `falsify` in `zigthesis.zig` updated to use an allocator for memory management.
>   - **Functions**:
>     - Added handling for `.Union`, `.Optional`, `.Pointer`, and `.Void` in `generateField`.
>     - Updated `getBoundaries` to handle unsigned integers.
>   - **Tests**:
>     - Added complex enum test in `test_falsify.zig`.
>     - Updated tests to cover new data types and structures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dianetc%2Fzigthesis&utm_source=github&utm_medium=referral)<sup> for c5ab65934af00b326c744ec7d31a091185fb6d15. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->