### PR TITLE
Configurability of test behavior

### DIFF
--- a/src/zigthesis.zig
+++ b/src/zigthesis.zig
@@ -1,21 +1,50 @@
 const std = @import("std");
 const generate = @import("generate.zig");
 const shrink = @import("shrink.zig");
-const MAX_DURATION_MS: u64 = 5 * 1000;
+ 
+pub const Error = error{
+    Failed,
+};
 
-pub fn falsify(predicate: anytype, test_name: []const u8) !void {
+fn defaultOnError(seed: u64, test_name: []const u8, args : anytype) Error!void {
+    std.debug.print("{s:<30} failed for {any} with seed {d}\n", .{ test_name, args, seed});
+}
+
+/// A function for onError that will fail the test.
+pub fn failOnError(seed: u64, test_name: []const u8, args : anytype) Error!void {
+    try defaultOnError(seed, test_name, args);
+    return error.Failed;
+}
+
+/// Config for falsification.
+/// max_duration_ms: The maximum duration of the test in milliseconds.
+/// max_iterations: The maximum number of iterations to run.
+/// The test will complete when it's performed max_iterations or max_duration_ms has passed.
+pub const Config = struct {
+    max_duration_ms: u64 = 5 * 1000,
+    max_iterations: u64 = std.math.maxInt(u64),
+    seed: ?u64 = null,
+    /// The function to call if the test fails.  It should return an error if the test is considered failed.
+    onError: fn (seed: u64, test_name: []const u8, args : anytype) Error!void = defaultOnError,
+};
+
+pub fn falsifyWith(predicate: anytype, test_name: []const u8, config: Config) !void {
     const predTypeInfo = @typeInfo(@TypeOf(predicate)).Fn;
     const start_time = std.time.milliTimestamp();
+    var seed: u64 = undefined;
     var prng = blk: {
-        var seed: u64 = undefined;
-        try std.posix.getrandom(std.mem.asBytes(&seed));
+        if (config.seed) |s| {
+            seed = s;
+        } else {
+            try std.posix.getrandom(std.mem.asBytes(&seed));
+        }
         break :blk std.rand.DefaultPrng.init(seed);
     };
     const random = prng.random();
 
-    while (true) {
+    for (0..config.max_iterations) |_| {
         const current_time = std.time.milliTimestamp();
-        if (current_time - start_time >= MAX_DURATION_MS) {
+        if (current_time - start_time >= config.max_duration_ms) {
             return;
         }
         var args: std.meta.ArgsTuple(@TypeOf(predicate)) = undefined;
@@ -25,10 +54,13 @@ pub fn falsify(predicate: anytype, test_name: []const u8) !void {
         const result = @call(.auto, predicate, args);
         if (!result) {
             args = shrinkArgs(predicate, args);
-            std.debug.print("{s:<30} failed for {any}\n", .{ test_name, args });
-            return;
+            return config.onError(seed,test_name, args);
         }
     }
+}
+
+pub fn falsify(predicate: anytype, test_name: []const u8) !void {
+    return falsifyWith(predicate, test_name, .{});
 }
 
 fn shrinkArgs(predicate: anytype, args: std.meta.ArgsTuple(@TypeOf(predicate))) std.meta.ArgsTuple(@TypeOf(predicate)) {


### PR DESCRIPTION
RFC:  What do  you think about being able to configure the behavior of the runner?

I was wondering why the tests were running kind of slow and found it's because they were always specified to run for exactly 5 seconds.  I'm used to having tests that run for a number of iterations, but duration is a pretty great idea, too.

I also found that the tests don't ever actually fail.  I wanted to make sure that if my code is broken, the test will fail.

So I added configuration for the following items;

* Duration (defaulting to 5 seconds, as default)
* Iterations (defaulting to max u64 value which is… hopefully enough)
* The random seed that was used/chosen, allowing for easy reproduction of failure
* OnError behavior

All of these default to the current behavior, but I provided a convenience function to allow the test to be marked as failed.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds configurability to test runner with options for duration, iterations, seed, and error handling, and updates tests accordingly.
> 
>   - **Behavior**:
>     - Adds configurability to test runner in `zigthesis.zig` with `Config` struct for `max_duration_ms`, `max_iterations`, `seed`, and `onError` behavior.
>     - Introduces `falsifyWith()` function to use the new `Config` struct.
>     - Default behavior remains unchanged unless configured.
>   - **Functions**:
>     - Adds `failOnError()` in `zigthesis.zig` to mark tests as failed on error.
>     - Modifies `generateField()` in `generate.zig` to handle more data types and use allocator.
>   - **Tests**:
>     - Updates `test_falsify.zig` to include tests for new configurations and data types.
>     - Adds tests for enum and struct handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dianetc%2Fzigthesis&utm_source=github&utm_medium=referral)<sup> for b9275b8446d2dbf80ea474eb6e2c5ba286ae263a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->