### PR TITLE
Unsigned Int Shrinking

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,7 +12,6 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/utils.zig"),
     });
 
-
     const exe = b.addExecutable(.{
         .name = "zigthesis",
         .root_source_file = b.path("src/main.zig"),
@@ -28,7 +27,6 @@ pub fn build(b: *std.Build) void {
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
-
     const test_step = b.step("test", "Run all tests");
 
     const tests = b.addTest(.{
@@ -40,5 +38,12 @@ pub fn build(b: *std.Build) void {
     tests.root_module.addImport("zigthesis", zigthesis_module);
     tests.root_module.addImport("utils", utils_module);
 
+    const internal_tests = b.addTest(.{
+        .root_source_file = b.path("src/zigthesis.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     test_step.dependOn(&b.addRunArtifact(tests).step);
+    test_step.dependOn(&b.addRunArtifact(internal_tests).step);
 }

--- a/src/shrink.zig
+++ b/src/shrink.zig
@@ -11,9 +11,37 @@ pub fn shrink(comptime T: type, value: T, predicate: anytype, args: anytype) T {
 }
 
 fn shrinkInt(comptime T: type, value: T, predicate: anytype, args: anytype) T {
-    if (T == u8){ return value; }
+    if (@typeInfo(T).int.signedness == .unsigned) {
+        return shrinkUnsignedInt(T, value, predicate, args);
+    } else {
+        return shrinkSignedInt(T, value, predicate, args);
+    }
+}
+
+fn shrinkUnsignedInt(comptime T: type, value: T, predicate: anytype, args: anytype) T {
     var current = value;
-    const targets = [_]T{0, 1, -1, @divTrunc(value, 2), @divTrunc(-value, 2)};
+    const targets = [_]T{ 0, 1 };
+
+    for (targets) |target| {
+        if (target != current and !predicate(target, args)) {
+            return target;
+        }
+    }
+
+    while (current != 0) {
+        const next = @divTrunc(current, 2);
+        if (next != current and !predicate(next, args)) {
+            return next;
+        }
+        current = next;
+    }
+
+    return value;
+}
+
+fn shrinkSignedInt(comptime T: type, value: T, predicate: anytype, args: anytype) T {
+    var current = value;
+    const targets = [_]T{ 0, 1, -1, @divTrunc(value, 2), @divTrunc(-value, 2) };
 
     for (targets) |target| {
         if (target != current and !predicate(target, args)) {
@@ -34,7 +62,7 @@ fn shrinkInt(comptime T: type, value: T, predicate: anytype, args: anytype) T {
 
 fn shrinkFloat(comptime T: type, value: T, predicate: anytype, args: anytype) T {
     var current = value;
-    const targets = [_]T{0, 1, -1, @divTrunc(value, 2), @divTrunc(-value, 2)};
+    const targets = [_]T{ 0, 1, -1, @divTrunc(value, 2), @divTrunc(-value, 2) };
 
     for (targets) |target| {
         if (target != current and !predicate(target, args)) {
@@ -60,13 +88,13 @@ fn shrinkArray(comptime T: type, value: T, predicate: anytype, args: anytype) T 
     while (i < info.len) : (i += 1) {
         var shrunk = value;
         shrunk[i] = shrink(info.child, value[i], struct {
-            fn inner(v: info.child, a: @TypeOf(.{args} ++ .{i, value})) bool {
-                var temp = a[a.len-1];
-                const curr = a[a.len-2];
+            fn inner(v: info.child, a: @TypeOf(.{args} ++ .{ i, value })) bool {
+                var temp = a[a.len - 1];
+                const curr = a[a.len - 2];
                 temp[curr] = v;
                 return predicate(temp, a[0]);
             }
-        }.inner, .{args} ++ .{i, value});
+        }.inner, .{args} ++ .{ i, value });
         if (!predicate(shrunk, args)) {
             return shrunk;
         }
@@ -80,14 +108,24 @@ fn shrinkStruct(comptime T: type, value: T, predicate: anytype, args: anytype) T
         var shrunk = value;
         @field(shrunk, field.name) = shrink(field.type, @field(value, field.name), struct {
             fn inner(v: field.type, a: @TypeOf(.{args} ++ .{value})) bool {
-                var temp = a[a.len-1];
+                var temp = a[a.len - 1];
                 @field(temp, field.name) = v;
                 return predicate(temp, a[0]);
             }
         }.inner, .{args} ++ .{value});
-       if (!predicate(shrunk, args)) {
+        if (!predicate(shrunk, args)) {
             return shrunk;
         }
     }
     return value;
+}
+
+test "unsigned shrinking" {
+    const T = struct {
+        fn lessThan(testval: u32, g: u32) bool {
+            return testval < 2 or testval > g;
+        }
+    };
+
+    try std.testing.expectEqual(3, shrink(u32, 1000, T.lessThan, 5));
 }

--- a/src/zigthesis.zig
+++ b/src/zigthesis.zig
@@ -1,6 +1,11 @@
 const std = @import("std");
 const generate = @import("generate.zig");
 const shrink = @import("shrink.zig");
+
+comptime {
+    if (@import("builtin").is_test) {
+        _ = @import("shrink.zig");
+    }}
  
 pub const Error = error{
     Failed,


### PR DESCRIPTION
Integer shrinking special cased u8, but tried negative numbers for other values.

This change splits signed and unsigned shrinking, providing a bit more functionality on the unsigned int shrinking and adds a low-level test for the shrinking directly covering this case.  This test did not compile before the change.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves integer shrinking by separating logic for signed and unsigned integers, adds a test for unsigned shrinking, and updates build and test configurations.
> 
>   - **Behavior**:
>     - Splits integer shrinking into `shrinkUnsignedInt` and `shrinkSignedInt` in `shrink.zig`.
>     - `shrinkUnsignedInt` now handles unsigned integers without attempting negative values.
>     - Adds a test for unsigned integer shrinking in `shrink.zig`.
>   - **Build**:
>     - Adds `internal_tests` for `src/zigthesis.zig` in `build.zig`.
>   - **Misc**:
>     - Minor formatting changes in `build.zig`.
>     - Ensures `shrink.zig` is imported during compile-time tests in `zigthesis.zig`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dianetc%2Fzigthesis&utm_source=github&utm_medium=referral)<sup> for 6357855243cf565cbdd54a9723d78a818c199a76. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->