### PR TITLE
Support enums

### DIFF
--- a/src/generate.zig
+++ b/src/generate.zig
@@ -80,6 +80,10 @@ pub fn generateField(alloc: std.mem.Allocator, random: std.Random, comptime T: t
             }
             return instance;
         },
+        .@"enum" => {
+            const enumInfo = typeInfo.@"enum";
+            return @enumFromInt(random.intRangeAtMost(usize, 0, enumInfo.fields.len - 1));
+        },
         .void => {
             return {};
         },

--- a/tests/test_falsify.zig
+++ b/tests/test_falsify.zig
@@ -81,7 +81,7 @@ test "Struct Test"{
     try zigthesis.falsify(simpleStruct, "field entries in struct");
 }
 
-const AnEnum = union(enum) {
+const AUnion = union(enum) {
     a : u8,
     b : u16,
     c : u32,
@@ -107,6 +107,16 @@ const AnEnum = union(enum) {
     w : []u64,
     x : []usize,
 };
+
+fn unionTest(instance: AnEnum) bool {
+    return instance == .a;
+}
+
+test "Union Test" {
+    try zigthesis.falsify(unionTest, "union test");
+}
+
+const AnEnum = enum { a, b, c };
 
 fn enumTest(instance: AnEnum) bool {
     return instance == .a;


### PR DESCRIPTION
Apparently I was a little confused when I added tagged union support and named it enums.  Enums are slightly different and weren't supported as I found by trying to use them.

Renamed the union tests to union and added enum tests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for enums in `generateField` and update tests to distinguish between enums and unions.
> 
>   - **Behavior**:
>     - Add support for enums in `generateField` in `generate.zig` by handling `.enum` in the switch statement.
>     - Generate random enum values using `@enumFromInt`.
>   - **Tests**:
>     - Rename `AnEnum` to `AUnion` and add `AnEnum` as a proper enum in `test_falsify.zig`.
>     - Add `unionTest` and `enumTest` functions to test union and enum handling respectively.
>     - Update test cases to distinguish between union and enum tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dianetc%2Fzigthesis&utm_source=github&utm_medium=referral)<sup> for b96485a5acaeb3d74d23c5aec5a394195f4f13c9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->